### PR TITLE
Added OSD related alerts

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -1,3 +1,4 @@
+(import 'monquorum.libsonnet') +
+(import 'osd.libsonnet') +
 (import 'state.libsonnet') +
-(import 'utilization.libsonnet') +
-(import 'monquorum.libsonnet')
+(import 'utilization.libsonnet')

--- a/alerts/osd.libsonnet
+++ b/alerts/osd.libsonnet
@@ -1,0 +1,155 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'osd-alert.rules',
+        rules: [
+          {
+            alert: 'CephOSDsDown',
+            expr: |||
+              (count(ceph_osd_up * on(ceph_daemon) ceph_osd_in == 0) > 0) and ((ceph_pg_total - on(job) ceph_pg_clean) > 0)
+            ||| % $._config,
+            'for': $._config.osdDownAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Additional load recovery places on ceph cluster. Client IO could be affected.',
+              description: 'Additional load recovery places on ceph cluster. Client IO could be affected.',
+              storage_type: $._config.storageType,
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'CephOSDDiskNotResponding',
+            expr: |||
+              label_replace((ceph_osd_in == 1 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation,"host","$1","exported_instance","(.*)")
+            ||| % $._config,
+            'for': $._config.osdDiskAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Disk not responding',
+              description: 'Disk not responding, on host {{ $labels.host }} (device {{ $labels.device }})',
+              storage_type: $._config.storageType,
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'CephOSDDiskUnavailable',
+            expr: |||
+              label_replace((ceph_osd_in == 0 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation,"host","$1","exported_instance","(.*)")
+            ||| % $._config,
+            'for': $._config.osdDiskAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Disk is inaccessible',
+              description: 'Disk inaccessible on host {{ $labels.host }} (device {{ $labels.device }})',
+              storage_type: $._config.storageType,
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'CephDataRecoveryActive',
+            expr: |||
+              rate(ceph_pg_undersized[30s]) > 0 and ceph_pg_undersized > 0
+            ||| % $._config,
+            'for': $._config.osdDataRecoveryInProgressAlertTime,
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              message: 'Data recovery is active',
+              description: 'Data recovery is active, resynchronizing data to the required data protection level',
+              storage_type: $._config.storageType,
+              severity_level: 'info',
+            },
+          },
+          {
+            alert: 'CephDataRecoveryQueued',
+            expr: |||
+              rate(ceph_pg_undersized[30s]) == 0 and ceph_pg_undersized > 0
+            ||| % $._config,
+            'for': $._config.osdDataRecoveryInProgressAlertTime,
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              message: 'Data recovery is queued',
+              description: 'Data recovery is queued',
+              storage_type: $._config.storageType,
+              severity_level: 'info',
+            },
+          },
+          {
+            alert: 'CephDataRecoveryTakingTooLong',
+            expr: |||
+              ceph_pg_undersized > 0
+            ||| % $._config,
+            'for': $._config.osdDataRecoveryAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Data recovery is slow',
+              description: 'Data recovery has been active for over %s. Contact Support' % $._config.osdDataRecoveryAlertTime,
+              storage_type: $._config.storageType,
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'CephDataRebalanceQueued',
+            expr: |||
+              rate(ceph_pg_remapped[30s]) == 0 and ceph_pg_remapped > 0 and ceph_pg_undersized == 0
+            ||| % $._config,
+            'for': $._config.osdDataRebalanceAlertTime,
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              message: 'Data rebalance queued',
+              description: 'Data rebalance is queued (rebalance improves disk utilization and performance)',
+              storage_type: $._config.storageType,
+              severity_level: 'info',
+            },
+          },
+          {
+            alert: 'CephDataRebalanceActive',
+            expr: |||
+              rate(ceph_pg_remapped[30s]) > 0 and ceph_pg_remapped > 0 and ceph_pg_undersized == 0
+            ||| % $._config,
+            'for': $._config.osdDataRebalanceAlertTime,
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              message: 'Data rebalance active',
+              description: 'Data rebalance is active (rebalance improves disk utilization and performance)',
+              storage_type: $._config.storageType,
+              severity_level: 'info',
+            },
+          },
+          {
+            alert: 'CephPGRepairTakingTooLong',
+            expr: |||
+              ceph_pg_inconsistent > 0
+            ||| % $._config,
+            'for': $._config.PGRepairAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Problems detected within self heal',
+              description: 'Self Heal operations taking too long. Contact Support',
+              storage_type: $._config.storageType,
+              severity_level: 'warning',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -4,9 +4,15 @@
     cephExporterSelector: 'job="rook-ceph-mgr"',
 
     // Duration to raise various Alerts
-    clusterUtilizationAlertTime: '5m',
     clusterStateAlertTime: '10m',
+    clusterUtilizationAlertTime: '5m',
     monQuorumAlertTime: '15m',
+    osdDataRebalanceAlertTime: '15s',
+    osdDataRecoveryAlertTime: '2h',
+    osdDataRecoveryInProgressAlertTime: '30s',
+    osdDiskAlertTime: '1m',
+    osdDownAlertTime: '5m',
+    PGRepairAlertTime: '1h',
 
     // Constants
     storageType: 'ceph',

--- a/extras/manifests/prometheus-rules.yaml
+++ b/extras/manifests/prometheus-rules.yaml
@@ -69,3 +69,111 @@ spec:
       for: 15m
       labels:
         severity: warning
+  - name: osd-alert.rules
+    rules:
+    - alert: CephOSDsDown
+      annotations:
+        description: Additional load recovery places on ceph cluster. Client IO could
+          be affected.
+        message: Additional load recovery places on ceph cluster. Client IO could
+          be affected.
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        (count(ceph_osd_up * on(ceph_daemon) ceph_osd_in == 0) > 0) and ((ceph_pg_total - on(job) ceph_pg_clean) > 0)
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CephOSDDiskNotResponding
+      annotations:
+        description: Disk not responding, on host {{ $labels.host }} (device {{ $labels.device
+          }})
+        message: Disk not responding
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        label_replace((ceph_osd_in == 1 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation,"host","$1","exported_instance","(.*)")
+      for: 1m
+      labels:
+        severity: warning
+    - alert: CephOSDDiskUnavailable
+      annotations:
+        description: Disk inaccessible on host {{ $labels.host }} (device {{ $labels.device
+          }})
+        message: Disk is inaccessible
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        label_replace((ceph_osd_in == 0 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation,"host","$1","exported_instance","(.*)")
+      for: 1m
+      labels:
+        severity: warning
+    - alert: CephDataRecoveryActive
+      annotations:
+        description: Data recovery is active, resynchronizing data to the required
+          data protection level
+        message: Data recovery is active
+        severity_level: info
+        storage_type: ceph
+      expr: |
+        rate(ceph_pg_undersized[30s]) > 0 and ceph_pg_undersized > 0
+      for: 30s
+      labels:
+        severity: info
+    - alert: CephDataRecoveryQueued
+      annotations:
+        description: Data recovery is queued
+        message: Data recovery is queued
+        severity_level: info
+        storage_type: ceph
+      expr: |
+        rate(ceph_pg_undersized[30s]) == 0 and ceph_pg_undersized > 0
+      for: 30s
+      labels:
+        severity: info
+    - alert: CephDataRecoveryTakingTooLong
+      annotations:
+        description: Data recovery has been active for over 2h. Contact Support
+        message: Data recovery is slow
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        ceph_pg_undersized > 0
+      for: 2h
+      labels:
+        severity: warning
+    - alert: CephDataRebalanceQueued
+      annotations:
+        description: Data rebalance is queued (rebalance improves disk utilization
+          and performance)
+        message: Data rebalance queued
+        severity_level: info
+        storage_type: ceph
+      expr: |
+        rate(ceph_pg_remapped[30s]) == 0 and ceph_pg_remapped > 0 and ceph_pg_undersized == 0
+      for: 15s
+      labels:
+        severity: info
+    - alert: CephDataRebalanceActive
+      annotations:
+        description: Data rebalance is active (rebalance improves disk utilization
+          and performance)
+        message: Data rebalance active
+        severity_level: info
+        storage_type: ceph
+      expr: |
+        rate(ceph_pg_remapped[30s]) > 0 and ceph_pg_remapped > 0 and ceph_pg_undersized == 0
+      for: 15s
+      labels:
+        severity: info
+    - alert: CephPGRepairTakingTooLong
+      annotations:
+        description: Self Heal operations taking too long. Contact Support
+        message: Problems detected within self heal
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        ceph_pg_inconsistent > 0
+      for: 1h
+      labels:
+        severity: warning


### PR DESCRIPTION
Added below alerts
 - CephOSDsDown
 - CephOSDDiskNotResponding
 - CephOSDDiskUnavailable
 - CephDataRecoveryActive
 - CephDataRecoveryQueued
 - CephDataRecoveryTakingTooLong
 - CephDataRebalanceQueued
 - CephDataRebalanceActive
 - CephPGRepairTakingTooLong

ceph-mixins-bug-id: ceph/ceph-mixins/issues/9
ceph-mixins-bug-id: ceph/ceph-mixins/issues/20
ceph-mixins-bug-id: ceph/ceph-mixins/issues/21
ceph-mixins-bug-id: ceph/ceph-mixins/issues/24

Signed-off-by: Shubhendu <shtripat@redhat.com>