### PR TITLE
Add version mismatch alerts

### DIFF
--- a/alerts/state.libsonnet
+++ b/alerts/state.libsonnet
@@ -46,7 +46,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'There are multiple versions of Ceph OSD running.',
+              message: 'There are multiple versions of storage services running.',
               description: 'There are {{ $value }} different versions of Ceph OSD components running.',
               storage_type: $._config.storageType,
               severity_level: 'warning',
@@ -62,7 +62,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'There are multiple versions of Ceph Mon running.',
+              message: 'There are multiple versions of storage services running.',
               description: 'There are {{ $value }} different versions of Ceph Mon components running.',
               storage_type: $._config.storageType,
               severity_level: 'warning',

--- a/alerts/state.libsonnet
+++ b/alerts/state.libsonnet
@@ -36,6 +36,34 @@
               severity_level: 'warning',
             },
           },
+          {
+            alert: 'CephOSDVersionMismatch',
+            expr: |||
+              count(count(ceph_osd_metadata{%(cephExporterSelector)s}) by (ceph_version)) > 1
+            ||| % $._config,
+            'for': '1h',
+            labels: {
+              'for': $._config.clusterVersionAlertTime,
+            },
+            annotations: {
+              message: 'There are {{ $value }} different versions of Ceph OSD components running.',
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'CephMonVersionMismatch',
+            expr: |||
+              count(count(ceph_mon_metadata{%(cephExporterSelector)s}) by (ceph_version)) > 1
+            ||| % $._config,
+            'for': $._config.clusterVersionAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'There are {{ $value }} different versions of Ceph Mon components running.',
+              severity_level: 'warning',
+            },
+          },
         ],
       },
     ],

--- a/alerts/state.libsonnet
+++ b/alerts/state.libsonnet
@@ -41,12 +41,14 @@
             expr: |||
               count(count(ceph_osd_metadata{%(cephExporterSelector)s}) by (ceph_version)) > 1
             ||| % $._config,
-            'for': '1h',
+            'for': $._config.clusterVersionAlertTime,
             labels: {
-              'for': $._config.clusterVersionAlertTime,
+              severity: 'warning',
             },
             annotations: {
-              message: 'There are {{ $value }} different versions of Ceph OSD components running.',
+              message: 'There are multiple versions of Ceph OSD running.',
+              description: 'There are {{ $value }} different versions of Ceph OSD components running.',
+              storage_type: $._config.storageType,
               severity_level: 'warning',
             },
           },
@@ -60,7 +62,9 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'There are {{ $value }} different versions of Ceph Mon components running.',
+              message: 'There are multiple versions of Ceph Mon running.',
+              description: 'There are {{ $value }} different versions of Ceph Mon components running.',
+              storage_type: $._config.storageType,
               severity_level: 'warning',
             },
           },

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -6,6 +6,7 @@
     // Duration to raise various Alerts
     cephNodeDownAlertTime: '30s',
     clusterStateAlertTime: '10m',
+    clusterVersionAlertTime: '10m',
     clusterUtilizationAlertTime: '5m',
     monQuorumAlertTime: '15m',
     osdDataRebalanceAlertTime: '15s',


### PR DESCRIPTION
Example:

```
  - "alert": "CephMonVersionMismatch"
    "annotations":
      "description": "There are {{ $value }} different versions of Ceph Mon components running."
      "message": "There are multiple versions of Ceph Mon running."
      "severity_level": "warning"
      "storage_type": "ceph"
    "expr": |
      count(count(ceph_mon_metadata{job="rook-ceph-mgr"}) by (ceph_version)) > 1
    "for": "10m"
    "labels":
      "severity": "warning"
  - "alert": "CephOSDVersionMismatch"
    "annotations":
      "description": "There are {{ $value }} different versions of Ceph OSD components running."
      "message": "There are multiple versions of Ceph OSD running."
      "severity_level": "warning"
      "storage_type": "ceph"
    "expr": |
      count(count(ceph_osd_metadata{job="rook-ceph-mgr"}) by (ceph_version)) > 1
    "for": "10m"
    "labels":
      "severity": "warning"

```