### PR TITLE
Add monquorum alert

### DIFF
--- a/alerts/monquorum.libsonnet
+++ b/alerts/monquorum.libsonnet
@@ -30,7 +30,10 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Ceph Monitor "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes recently',
+              message: 'Ceph Monitor has seen many leader changes recently.',
+              description: 'Ceph Monitor "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes recently.',
+              storage_type: $._config.storageType,
+              severity_level: 'warning',
             },
           },
         ],

--- a/alerts/monquorum.libsonnet
+++ b/alerts/monquorum.libsonnet
@@ -30,7 +30,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Ceph Monitor has seen many leader changes recently.',
+              message: 'Storage Cluster has seen many leader changes recently.',
               description: 'Ceph Monitor "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes recently.',
               storage_type: $._config.storageType,
               severity_level: 'warning',

--- a/alerts/monquorum.libsonnet
+++ b/alerts/monquorum.libsonnet
@@ -7,8 +7,8 @@
           {
             alert: 'CephMonQuorumAtRisk',
             expr: |||
-              count(ceph_mon_quorum_status == 1) <= ((count(ceph_mon_metadata) %s 2) + 1)
-            ||| % '%',
+              count(ceph_mon_quorum_status{%s} == 1) <= ((count(ceph_mon_metadata{%s}) %s 2) + 1)
+            ||| % [$._config.cephExporterSelector, $._config.cephExporterSelector, '%'],
             'for': $._config.monQuorumAlertTime,
             labels: {
               severity: 'critical',
@@ -18,6 +18,19 @@
               description: 'Storage cluster quorum is low. Contact Support.',
               storage_type: $._config.storageType,
               severity_level: 'error',
+            },
+          },
+          {
+            alert: 'CephMonHighNumberOfLeaderChanges',
+            expr: |||
+              rate(ceph_mon_num_elections{%(cephExporterSelector)s}[15m]) > 3
+            ||| % $._config,
+            'for': $._config.monQuorumLeaderChangesAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Ceph Monitor "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes recently',
             },
           },
         ],

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -8,6 +8,7 @@
     clusterStateAlertTime: '10m',
     clusterUtilizationAlertTime: '5m',
     monQuorumAlertTime: '15m',
+    monQuorumLeaderChangesAlertTime: '30m',
     osdDataRebalanceAlertTime: '15s',
     osdDataRecoveryAlertTime: '2h',
     osdDataRecoveryInProgressAlertTime: '30s',

--- a/extras/manifests/prometheus-ceph-rules.yaml
+++ b/extras/manifests/prometheus-ceph-rules.yaml
@@ -25,10 +25,22 @@ spec:
         severity_level: error
         storage_type: ceph
       expr: |
-        count(ceph_mon_quorum_status == 1) <= ((count(ceph_mon_metadata) % 2) + 1)
+        count(ceph_mon_quorum_status{job="rook-ceph-mgr"} == 1) <= ((count(ceph_mon_metadata{job="rook-ceph-mgr"}) % 2) + 1)
       for: 15m
       labels:
         severity: critical
+    - alert: CephMonHighNumberOfLeaderChanges
+      annotations:
+        description: 'Ceph Monitor "{{ $labels.job }}": instance {{ $labels.instance
+          }} has seen {{ $value }} leader changes recently.'
+        message: Storage Cluster has seen many leader changes recently.
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        rate(ceph_mon_num_elections{job="rook-ceph-mgr"}[15m]) > 3
+      for: 30m
+      labels:
+        severity: warning
   - name: ceph-node-alert.rules
     rules:
     - alert: CephNodeDown


### PR DESCRIPTION
Adds `CephMonHighNumberOfLeaderChanges`
Fixes `CephMonQuorumAtRisk` to add label selector. In the case where you have multiple clusters monitored by same Prometheus instance.


Example output:

```
"groups":
- "name": "quorum-alert.rules"
  "rules":
  - "alert": "CephMonQuorumAtRisk"
    "annotations":
      "description": "Storage cluster quorum is low. Contact Support."
      "message": "Storage quorum at risk"
      "severity_level": "error"
      "storage_type": "ceph"
    "expr": |
      count(ceph_mon_quorum_status{job="rook-ceph-mgr"} == 1) <= ((count(ceph_mon_metadata{job="rook-ceph-mgr"}) % 2) + 1)
    "for": "15m"
    "labels":
      "severity": "critical"
  - "alert": "CephMonHighNumberOfLeaderChanges"
    "annotations":
      "description": "Ceph Monitor \"{{ $labels.job }}\": instance {{ $labels.instance }} has seen {{ $value }} leader changes recently."
      "message": "Storage Cluster has seen many leader changes recently."
      "severity_level": "warning"
      "storage_type": "ceph"
    "expr": |
      rate(ceph_mon_num_elections{job="rook-ceph-mgr"}[15m]) > 3
    "for": "30m"
    "labels":
      "severity": "warning"
```