### PR TITLE
Add OSD low space alert

### DIFF
--- a/alerts/osd.libsonnet
+++ b/alerts/osd.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'CephOSDDiskNotResponding',
             expr: |||
-              label_replace((ceph_osd_in == 1 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation,"host","$1","exported_instance","(.*)")
+              label_replace((ceph_osd_in{%(cephExporterSelector)s} == 1 and ceph_osd_up{%(cephExporterSelector)s} == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation{%(cephExporterSelector)s},"host","$1","exported_instance","(.*)")
             ||| % $._config,
             'for': $._config.osdDiskAlertTime,
             labels: {
@@ -23,7 +23,7 @@
           {
             alert: 'CephOSDDiskUnavailable',
             expr: |||
-              label_replace((ceph_osd_in == 0 and ceph_osd_up == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation,"host","$1","exported_instance","(.*)")
+              label_replace((ceph_osd_in{%(cephExporterSelector)s} == 0 and ceph_osd_up{%(cephExporterSelector)s} == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation{%(cephExporterSelector)s},"host","$1","exported_instance","(.*)")
             ||| % $._config,
             'for': $._config.osdDiskAlertTime,
             labels: {
@@ -39,7 +39,7 @@
           {
             alert: 'CephDataRecoveryTakingTooLong',
             expr: |||
-              ceph_pg_undersized > 0
+              ceph_pg_undersized{%(cephExporterSelector)s} > 0
             ||| % $._config,
             'for': $._config.osdDataRecoveryAlertTime,
             labels: {
@@ -55,7 +55,7 @@
           {
             alert: 'CephPGRepairTakingTooLong',
             expr: |||
-              ceph_pg_inconsistent > 0
+              ceph_pg_inconsistent{%(cephExporterSelector)s} > 0
             ||| % $._config,
             'for': $._config.PGRepairAlertTime,
             labels: {
@@ -66,6 +66,18 @@
               description: 'Self heal operations taking too long. Contact Support.',
               storage_type: $._config.storageType,
               severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'CephOSDLowSpace',
+            expr: |||
+              (ceph_osd_stat_bytes_used{%(cephExporterSelector)s} / ceph_osd_stat_bytes{%(cephExporterSelector)s}) * 100 > 85
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{$labels.ceph_daemon}} Ceph OSD used more than 85 % of disk space.',
             },
           },
         ],


### PR DESCRIPTION
Adds OSD low space alert.

Additionally fixes osd alerts to have label selectors.

Output:
```
  - "alert": "CephOSDLowSpace"
    "annotations":
      "message": "{{$labels.ceph_daemon}} Ceph OSD used more than 85 % of disk space."
    "expr": |
      (ceph_osd_stat_bytes_used{job="rook-ceph-mgr"} / ceph_osd_stat_bytes{job="rook-ceph-mgr"}) * 100 > 85
    "labels":
      "severity": "warning"
```

Fixes:

```
- "name": "osd-alert.rules"
  "rules":
  - "alert": "CephOSDDiskNotResponding"
    "annotations":
      "description": "Disk device {{ $labels.device }} not responding, on host {{ $labels.host }}."
      "message": "Disk not responding"
      "severity_level": "error"
      "storage_type": "ceph"
    "expr": |
      label_replace((ceph_osd_in{job="rook-ceph-mgr"} == 1 and ceph_osd_up{job="rook-ceph-mgr"} == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation{job="rook-ceph-mgr"},"host","$1","exported_instance","(.*)")
    "for": "1m"
    "labels":
      "severity": "critical"
  - "alert": "CephOSDDiskUnavailable"
    "annotations":
      "description": "Disk device {{ $labels.device }} not accessible on host {{ $labels.host }}."
      "message": "Disk not accessible"
      "severity_level": "error"
      "storage_type": "ceph"
    "expr": |
      label_replace((ceph_osd_in{job="rook-ceph-mgr"} == 0 and ceph_osd_up{job="rook-ceph-mgr"} == 0),"disk","$1","ceph_daemon","osd.(.*)") + on(ceph_daemon) group_left(host, device) label_replace(ceph_disk_occupation{job="rook-ceph-mgr"},"host","$1","exported_instance","(.*)")
    "for": "1m"
    "labels":
      "severity": "critical"
  - "alert": "CephDataRecoveryTakingTooLong"
    "annotations":
      "description": "Data recovery has been active for more than 2h. Contact Support."
      "message": "Data recovery is slow"
      "severity_level": "warning"
      "storage_type": "ceph"
    "expr": |
      ceph_pg_undersized{job="rook-ceph-mgr"} > 0
    "for": "2h"
    "labels":
      "severity": "warning"
```