### PR TITLE
Allow setting mds number

### DIFF
--- a/alerts/absent_alerts.libsonnet
+++ b/alerts/absent_alerts.libsonnet
@@ -44,7 +44,7 @@
           {
             alert: 'CephMdsMissingReplicas',
             expr: |||
-              sum(ceph_mds_metadata{%(cephExporterSelector)s} == 1) < 2
+              sum(ceph_mds_metadata{%(cephExporterSelector)s} == 1) < %(cephMdsCount)d
             ||| % $._config,
             'for': $._config.mdsMissingReplicasAlertTime,
             labels: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -5,6 +5,8 @@
 
     // Expected number of Ceph Managers which are reporting metrics
     cephMgrCount: 1,
+    // Expected number of Ceph Mds which are reporting metrics
+    cephMdsCount: 2,
 
     // Duration to raise various Alerts
     cephNodeDownAlertTime: '30s',


### PR DESCRIPTION
In our case this alert is firing, but it shouldn't
```
ceph mds stat
kube-1/1/1 up  {0=server.server.com=up:active}, 2 up:standby
```

promql:
```
ceph_mds_metadata{job="ceph"}
```

Results in a single metric:

```
ceph_mds_metadata{ceph_daemon="mds.server.server.com",ceph_version="ceph version 13.2.4 (b10be4d44915a4d78a8e06aa31919e74927b142e) mimic (stable)",fs_id="1",hostname="server.server.com",instance="...:9283",job="ceph",public_addr="172.16.110.39:6800/4125598060",rank="0"} 1
```