### PR TITLE
Fix 'CephOSDVersionMismatch' and 'CephMonVersionMismatch' alerts

### DIFF
--- a/alerts/state.libsonnet
+++ b/alerts/state.libsonnet
@@ -31,7 +31,7 @@
             },
             annotations: {
               message: 'Storage cluster is in degraded state',
-              description: 'Storage cluster is in warning state for more than %s.' % $._config.clusterStateAlertTime,
+              description: 'Storage cluster is in warning state for more than %s.' % $._config.clusterWarningStateAlertTime,
               storage_type: $._config.storageType,
               severity_level: 'warning',
             },

--- a/alerts/state.libsonnet
+++ b/alerts/state.libsonnet
@@ -39,7 +39,7 @@
           {
             alert: 'CephOSDVersionMismatch',
             expr: |||
-              count(count(ceph_osd_metadata{%(cephExporterSelector)s}) by (ceph_version, namespace)) by (ceph_version, namespace) > 1
+              count by (namespace) (count by (ceph_version, namespace) (ceph_osd_metadata{%(cephExporterSelector)s, ceph_version != ""})) > 1
             ||| % $._config,
             'for': $._config.clusterVersionAlertTime,
             labels: {
@@ -55,7 +55,7 @@
           {
             alert: 'CephMonVersionMismatch',
             expr: |||
-              count(count(ceph_mon_metadata{%(cephExporterSelector)s, ceph_version != ""}) by (ceph_version)) > 1
+              count by (namespace) (count by (ceph_version, namespace) (ceph_mon_metadata{%(cephExporterSelector)s, ceph_version != ""})) > 1
             ||| % $._config,
             'for': $._config.clusterVersionAlertTime,
             labels: {

--- a/extras/manifests/prometheus-ceph-rules.yaml
+++ b/extras/manifests/prometheus-ceph-rules.yaml
@@ -247,7 +247,7 @@ spec:
         severity: critical
     - alert: CephClusterWarningState
       annotations:
-        description: Storage cluster is in warning state for more than 10m.
+        description: Storage cluster is in warning state for more than 15m.
         message: Storage cluster is in degraded state
         severity_level: warning
         storage_type: ceph

--- a/extras/manifests/prometheus-ceph-rules.yaml
+++ b/extras/manifests/prometheus-ceph-rules.yaml
@@ -263,7 +263,7 @@ spec:
         severity_level: warning
         storage_type: ceph
       expr: |
-        count(count(ceph_osd_metadata{job="rook-ceph-mgr"}) by (ceph_version, namespace)) by (ceph_version, namespace) > 1
+        count by (namespace) (count by (ceph_version, namespace) (ceph_osd_metadata{job="rook-ceph-mgr", ceph_version != ""})) > 1
       for: 10m
       labels:
         severity: warning
@@ -274,7 +274,7 @@ spec:
         severity_level: warning
         storage_type: ceph
       expr: |
-        count(count(ceph_mon_metadata{job="rook-ceph-mgr", ceph_version != ""}) by (ceph_version)) > 1
+        count by (namespace) (count by (ceph_version, namespace) (ceph_mon_metadata{job="rook-ceph-mgr", ceph_version != ""})) > 1
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Alerts, 'CephOSDVersionMismatch' and 'CephMonVersionMismatch' had a
minor issue in the query. Earlier we were counting a combination of
'namespace' and 'ceph_version' both times, but in actual we should count
only by 'namespace' thus making sure we don't have more than one ceph
versions in a single namespace.